### PR TITLE
Fix Z-Way re-authentication issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,8 +171,7 @@ ZWayServerPlatform.prototype = {
                         "Accept": "application/json",
                         "Content-Type": "application/json"
                     },
-                    json: true,
-                    jar: true//that.jar
+                    json: true
                 }, function(error, response, body){
                     if(response && response.statusCode == 200){
                         that.sessionId = body.data.sid;


### PR DESCRIPTION
Disable cookie header on Z-Way login POST request by omitting requests jar option

This was causing a stale cookie value to be sent along with a new login request, causing it to fail 